### PR TITLE
fix: remove extra spaces in DaemonSet tolerations definition

### DIFF
--- a/openshift/deployment.yaml
+++ b/openshift/deployment.yaml
@@ -45,8 +45,8 @@ spec:
     spec:
       tolerations:
       - effect: NoSchedule
-         key: node-role.kubernetes.io/master
-         operator: Exists
+        key: node-role.kubernetes.io/master
+        operator: Exists
       serviceAccount: gadget
       hostPID: true
       hostNetwork: true


### PR DESCRIPTION
This fix is required for a successful deployment of DaemonSet

Otherwise, we get an error

```
error: error parsing https://raw.githubusercontent.com/clustership/inspektor-gadget/master/openshift/deployment.yaml
error converting YAML to JSON: yaml: line 22: mapping values are not allowed in this context
```